### PR TITLE
Add AWS SES for sending emails

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 class ApplicationMailer < ActionMailer::Base
+  default "Message-ID" => lambda {"<#{SecureRandom.uuid}@#{ENV["HOST"]}>"}
   default from: ENV["SUPPORT_EMAIL"]
   layout "mailer"
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class ApplicationMailer < ActionMailer::Base
-  default "Message-ID" => lambda {"<#{SecureRandom.uuid}@#{ENV["HOST"]}>"}
+  default "Message-ID" => lambda { "<#{SecureRandom.uuid}@#{ENV["HOST"]}>" }
   default from: ENV["SUPPORT_EMAIL"]
   layout "mailer"
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -65,16 +65,6 @@ Rails.application.configure do
   # configuration for devise mailer
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-    address: "smtp.sendgrid.net",
-    port: 587,
-    user_name: "apikey",
-    password: ENV["SENDGRID_API_KEY"],
-    authentication: "plain",
-    enable_starttls_auto: true,
-  }
-
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,10 +68,10 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.default_url_options = { host: ENV["HOST"] }
   config.action_mailer.smtp_settings = {
-    address: "smtp.sendgrid.net",
+    address: "email-smtp.us-east-1.amazonaws.com",
     port: 587,
-    user_name: "apikey",
-    password: ENV["SENDGRID_API_KEY"],
+    user_name: ENV["MAIL_USERNAME"],
+    password: ENV["MAIL_PASSWORD"],
     authentication: "plain",
     enable_starttls_auto: true,
   }

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+  config.mailer_sender = ENV["SUPPORT_EMAIL"]
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = ENV["SUPPORT_EMAIL"]
+  config.mailer_sender = Rails.env.production? ? ENV["SUPPORT_EMAIL"] : 'user@example.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
# Summary
SendGrid API was not working atm so need to replace that with [AWS SES](https://aws.amazon.com/ses/) for sending emails

## Check List

- [x] Replace Sendgrid api keys with ses
- [x] Update mailer_sender for devise emails
- [x] revert development configs regarding emails