### PR TITLE
Add dependent destory for user tasks

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
     :recoverable, :rememberable, :validatable, :confirmable
 
-  has_many :tasks
+  has_many :tasks, dependent: :destroy
 
   def after_confirmation
     # TODO: replace perform_now with perform_later

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe(User, type: :model) do
     it "destroys dependent tasks" do
       user.destroy!
 
-      expect(user.tasks.count).to eq(0)
+      expect(user.tasks.count).to(eq(0))
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,6 +7,15 @@ RSpec.describe(User, type: :model) do
   end
 
   describe "associations" do
+    let!(:user) { create(:user) }
+    let!(:tasks) { create_list(:task, 5, user: user) }
+
     it { should have_many(:tasks) }
+
+    it "destroys dependent tasks" do
+      user.destroy!
+
+      expect(user.tasks.count).to eq(0)
+    end
   end
 end


### PR DESCRIPTION
# Summary
Add `dependent: :destroy` for user tasks to avoid db constraint errors while destroying users

## Check List

- [x] Add `dependent: :destroy ` in user model
- [x] Add tests